### PR TITLE
Support `markmap` tag

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ const escapeHTML = str => str.replace(/&/g, '&amp;')
 
 const handler = page => {
     let result;
+    page.content = page.content.replace("```markmap","```mind");
 
     while ((result = reg.exec(page.content))) {
         const [block, conditions, content] = result;


### PR DESCRIPTION
`Visual Studio` only supports the `markmap` tag;

In order to unify the writing style, add additional keyword recognition